### PR TITLE
Implemented loading of subregion

### DIFF
--- a/src/main/java/fr/igred/ij/plugin/OMEROMacroExtension.java
+++ b/src/main/java/fr/igred/ij/plugin/OMEROMacroExtension.java
@@ -1110,12 +1110,13 @@ public class OMEROMacroExtension implements PlugIn, MacroExtension {
                         startEmpty = matcher.group(i + 1) == null || matcher.group(i + 1).isEmpty();
                         sepEmpty = matcher.group(i + 2) == null || matcher.group(i + 2).isEmpty();
                         endEmpty = matcher.group(i + 3) == null || matcher.group(i + 3).isEmpty();
-                        if((startEmpty && sepEmpty && endEmpty) || coordinateType == null)
+                        if((startEmpty && endEmpty) || coordinateType == null)
+                            // Invalid input or in the form z: or z::
                             continue;
 
                         start = startEmpty ? 0 : Integer.parseInt(matcher.group(i + 1));
                         if(sepEmpty)
-                            end = start; // There is no second separator, indicates a single slice
+                            end = start; // Input is like z:5  it's a single slice
                         else
                             end = endEmpty ? -1 : (Integer.parseInt(matcher.group(i + 3)) - 1);
                         switch(coordinateType) {
@@ -1460,8 +1461,7 @@ public class OMEROMacroExtension implements PlugIn, MacroExtension {
                 break;
 
             case "getImage":
-                String bounds = (String) args[1];
-                ImagePlus imp = getImage(((Double) args[0]).longValue(), bounds);
+                ImagePlus imp = getImage(((Double) args[0]).longValue(), (String) args[1]);
                 if (imp != null) {
                     imp.show();
                     results = String.valueOf(imp.getID());

--- a/src/main/java/fr/igred/ij/plugin/OMEROMacroExtension.java
+++ b/src/main/java/fr/igred/ij/plugin/OMEROMacroExtension.java
@@ -1076,9 +1076,12 @@ public class OMEROMacroExtension implements PlugIn, MacroExtension {
 
 
     /**
-     * Opens an image.
+     * Opens an image with optional bounds.
+     * The bounds are in the form "x:min:max" with max included. Each of
+     * XYCZT is optional, min and max are also optional: "x:0:100 y::200 z:5: t::"
      *
      * @param id The image ID.
+     * @param bounds The XYCZT bounds
      *
      * @return The image, as an {@link ImagePlus}.
      */

--- a/src/main/java/fr/igred/ij/plugin/OMEROMacroExtension.java
+++ b/src/main/java/fr/igred/ij/plugin/OMEROMacroExtension.java
@@ -1093,7 +1093,7 @@ public class OMEROMacroExtension implements PlugIn, MacroExtension {
                 imp = image.toImagePlus(client);
             else {
                 // Regex captures in any order XYCZT coordinates of the form x:: x:0: x::100 x:0:100 c:0
-                String regexPattern = "(?:(x):(\\d*)(:?)(\\d*))?(?:(y):(\\d*)(:?)(\\d*))?(?:(c):(\\d*)(:?)(\\d*))?(?:(z):(\\d*)(:?)(\\d*))?(?:(t):(\\d*)(:?)(\\d*))?";
+                String regexPattern = "(?:([xyczt]):(\\d*)(:?)(\\d*))";
                 Pattern pattern = Pattern.compile(regexPattern, Pattern.CASE_INSENSITIVE);
                 Matcher matcher = pattern.matcher(bounds);
 
@@ -1110,8 +1110,7 @@ public class OMEROMacroExtension implements PlugIn, MacroExtension {
                         startEmpty = matcher.group(i + 1) == null || matcher.group(i + 1).isEmpty();
                         sepEmpty = matcher.group(i + 2) == null || matcher.group(i + 2).isEmpty();
                         endEmpty = matcher.group(i + 3) == null || matcher.group(i + 3).isEmpty();
-                        if((startEmpty && endEmpty) || coordinateType == null)
-                            // Invalid input or in the form z: or z::
+                        if(startEmpty && endEmpty) // in the form z: or z::
                             continue;
 
                         start = startEmpty ? 0 : Integer.parseInt(matcher.group(i + 1));
@@ -1119,7 +1118,7 @@ public class OMEROMacroExtension implements PlugIn, MacroExtension {
                             end = start; // Input is like z:5  it's a single slice
                         else
                             end = endEmpty ? -1 : (Integer.parseInt(matcher.group(i + 3)) - 1);
-                        switch(coordinateType) {
+                        switch(coordinateType.toLowerCase()) {
                             case "x":
                                 xBounds[0] = start;
                                 xBounds[1] = end;

--- a/src/main/resources/script_templates/OMERO/Macro_Extensions/Subregion_from_rois.ijm
+++ b/src/main/resources/script_templates/OMERO/Macro_Extensions/Subregion_from_rois.ijm
@@ -1,0 +1,36 @@
+// @String(label="Username") USERNAME
+// @String(label="Password", style='password', persist=false) PASSWORD
+// @String(label="Host", value='wss://workshop.openmicroscopy.org/omero-ws') HOST
+// @Integer(label="Port", value=443) PORT
+// @Integer(label="Image ID", value=2331) image_id
+
+run("OMERO Extensions");
+
+//Connect to OMERO
+connected = Ext.connectToOMERO(HOST, PORT, USERNAME, PASSWORD);
+
+//Need an image in Fiji to load ROIs
+newImage("tmp_load", "8-bit color-mode", 1, 1, 1, 1, 1);
+
+ij_id = Ext.getROIs(image_id);
+roiManager("list");
+for(i=0; i<RoiManager.size; i++){
+	name = getResultString("Name", i);
+	x1 = getResult("X", i);
+	x2 = getResult("Width", i) + x1 - 1;
+	y1 = getResult("Y", i);
+	y2 = getResult("Height", i) + y1 - 1;
+	bounds = String.format("x:%.0f:%.0f y:%.0f:%.0f", x1,x2,y1,y2);
+	
+	c = getResult("C", i);
+	z = getResult("Z", i);
+	t = getResult("T", i);
+	if(c>0) bounds = bounds + " c:"+(c-1);
+	if(z>0) bounds = bounds + " z:"+(z-1);
+	if(t>0) bounds = bounds + " t:"+(t-1);
+	print(bounds);
+	Ext.getImage(image_id, bounds);
+	rename(getTitle() + "["+name+"]");
+}
+close("tmp_load");
+Ext.disconnect();

--- a/src/main/resources/script_templates/OMERO/Macro_Extensions/Subregion_save_rois.ijm
+++ b/src/main/resources/script_templates/OMERO/Macro_Extensions/Subregion_save_rois.ijm
@@ -1,0 +1,53 @@
+// @String(label="Username") USERNAME
+// @String(label="Password", style='password', persist=false) PASSWORD
+// @String(label="Host", value='wss://workshop.openmicroscopy.org/omero-ws') HOST
+// @Integer(label="Port", value=443) PORT
+// @Integer(label="Image ID", value=2331) image_id
+
+run("OMERO Extensions");
+
+//Connect to OMERO
+connected = Ext.connectToOMERO(HOST, PORT, USERNAME, PASSWORD);
+
+// Possible syntax for subregion (same for each coordinate):
+// "x:200:400"  select in X from 200 to 400, [incl, excl[
+// "x:200:"     select in X from 200  (alias of "x:200:-1")
+// "x::400"     select in X up to 400 (alias of "x:0:400")
+// "z:10"       select the slice 10
+// "z:10 x:200:400" combine them in any order
+x = newArray(50, 150);
+y = newArray(100, -1);
+c = newArray(1, 2);
+z = newArray(2, 4);
+t = newArray(5, 10);
+
+// Putting it all together
+bounds = String.format("x:%.0f:%.0f y:%.0f:%.0f c:%.0f:%.0f z:%.0f:%.0f t:%.0f:%.0f", x[0], x[1], y[0], y[1], c[0], c[1], z[0], z[1], t[0], t[1]);
+
+ij_id = Ext.getImage(image_id, bounds);
+
+// ROI creation and assigning it to a specific slice
+makeRectangle(8, 8, 4, 4);
+roiManager("add");
+roiManager("select", 0);
+RoiManager.setPosition(2); // Assign to the second slice in Fiji
+
+save_rois(x[0], y[0], c[0], z[0], t[0]); // Calls Ext.saveROIs(image_id) after shifting the ROIs
+Ext.disconnect();
+
+function save_rois(dx, dy, dc, dz, dt){
+	// ROIs needs to be translated and assigned to the correct image slice on OMERO
+	n = roiManager("count");
+	for (i=0; i<n; i++) {
+	  roiManager("select", i);
+	  Roi.getPosition(channel, slice, frame); // If a previous channel/slice/frame is set to ROI, use that as starting point before shifting
+
+	  if (channel>0) channel = dc + channel; // offset 'channel' with the 0-indexed value 'dc'
+	  if (slice>0) slice = dz + slice;
+	  if (frame>0) frame = dt + frame;
+	  
+	  RoiManager.setPosition(channel, slice, frame);
+	  RoiManager.translate(dx, dy);
+	}
+	Ext.saveROIs(image_id);
+}

--- a/src/test/java/fr/igred/ij/plugin/OMEROExtensionErrorTest.java
+++ b/src/test/java/fr/igred/ij/plugin/OMEROExtensionErrorTest.java
@@ -136,7 +136,7 @@ class OMEROExtensionErrorTest {
 
     @Test
     void testGetImageError() {
-        Object[] args = {-1.0d};
+        Object[] args = {-1.0d, null};
         ext.handleExtension("getImage", args);
         String expected = "Could not retrieve image: Image -1 doesn't exist in this context";
         assertEquals(expected, outContent.toString().trim());

--- a/src/test/java/fr/igred/ij/plugin/OMEROExtensionTest.java
+++ b/src/test/java/fr/igred/ij/plugin/OMEROExtensionTest.java
@@ -316,7 +316,7 @@ class OMEROExtensionTest {
     @Test
     void testGetImage() {
         final int size = 512;
-        ImagePlus imp  = ext.getImage(1L);
+        ImagePlus imp  = ext.getImage(1L, null);
         assertEquals(size, imp.getWidth());
         assertEquals(size, imp.getHeight());
     }
@@ -324,7 +324,7 @@ class OMEROExtensionTest {
 
     @Test
     void testSaveAndGetROIs() {
-        ImagePlus imp     = ext.getImage(1L);
+        ImagePlus imp     = ext.getImage(1L, null);
         Overlay   overlay = new Overlay();
         Roi       roi     = new Roi(25, 30, 70, 50);
         roi.setImage(imp);

--- a/src/test/java/fr/igred/ij/plugin/OMEROExtensionTest.java
+++ b/src/test/java/fr/igred/ij/plugin/OMEROExtensionTest.java
@@ -321,6 +321,22 @@ class OMEROExtensionTest {
         assertEquals(size, imp.getHeight());
     }
 
+    @Test
+    void testGetImageTwoBounds() {
+        final int partSize = 100;
+        final int fullSize = 512;
+        ImagePlus imp  = ext.getImage(1L, "x:100:200 y:0:512");
+        assertEquals(partSize, imp.getWidth());
+        assertEquals(fullSize, imp.getHeight());
+    }
+
+    @Test
+    void testGetImageOneBound() {
+        final int size = 412;
+        ImagePlus imp  = ext.getImage(1L, "x:100: y::412");
+        assertEquals(size, imp.getWidth());
+        assertEquals(size, imp.getHeight());
+    }
 
     @Test
     void testSaveAndGetROIs() {

--- a/src/test/java/fr/igred/ij/plugin/OMEROExtensionTest.java
+++ b/src/test/java/fr/igred/ij/plugin/OMEROExtensionTest.java
@@ -361,7 +361,7 @@ class OMEROExtensionTest {
 
 
     @ParameterizedTest
-    @ValueSource(strings = {"", "  ", "x: y:: ", "x::9999 y:0:9999 z:50:99 c::99 t::99"})
+    @ValueSource(strings = {"", "  ", "x: y:: ", "x::9999 y:0:9999 z:50:99 c::99 t::99", "^#azerty*$"})
     void testGetImageNoBounds(String bounds) {
         final int size = 512;
         final int sizeZ = 3;

--- a/src/test/java/fr/igred/ij/plugin/OMEROExtensionTest.java
+++ b/src/test/java/fr/igred/ij/plugin/OMEROExtensionTest.java
@@ -321,6 +321,7 @@ class OMEROExtensionTest {
         assertEquals(size, imp.getHeight());
     }
 
+
     @Test
     void testGetImageTwoBounds() {
         final int partSize = 100;
@@ -330,6 +331,7 @@ class OMEROExtensionTest {
         assertEquals(fullSize, imp.getHeight());
     }
 
+
     @Test
     void testGetImageOneBound() {
         final int size = 412;
@@ -337,6 +339,67 @@ class OMEROExtensionTest {
         assertEquals(size, imp.getWidth());
         assertEquals(size, imp.getHeight());
     }
+
+
+    @Test
+    void testGetImageEmptyBounds() {
+        final int size = 512;
+        final int sizeZ = 3;
+        final int sizeC = 5;
+        final int sizeT = 7;
+        ImagePlus imp  = ext.getImage(1L, "x: ");
+        assertEquals(size, imp.getWidth());
+        assertEquals(size, imp.getHeight());
+        assertEquals(sizeZ, imp.getNSlices());
+        assertEquals(sizeC, imp.getNChannels());
+        assertEquals(sizeT, imp.getNFrames());
+    }
+
+
+    @Test
+    void testGetImageZ() {
+        final int size = 512;
+        final int sizeZ = 1;
+        final int sizeC = 5;
+        final int sizeT = 7;
+        ImagePlus imp  = ext.getImage(1L, "z:0");
+        assertEquals(size, imp.getWidth());
+        assertEquals(size, imp.getHeight());
+        assertEquals(sizeZ, imp.getNSlices());
+        assertEquals(sizeC, imp.getNChannels());
+        assertEquals(sizeT, imp.getNFrames());
+    }
+
+
+    @Test
+    void testGetImageC() {
+        final int size = 512;
+        final int sizeZ = 3;
+        final int sizeC = 1;
+        final int sizeT = 7;
+        ImagePlus imp  = ext.getImage(1L, "c:0");
+        assertEquals(size, imp.getWidth());
+        assertEquals(size, imp.getHeight());
+        assertEquals(sizeZ, imp.getNSlices());
+        assertEquals(sizeC, imp.getNChannels());
+        assertEquals(sizeT, imp.getNFrames());
+    }
+
+
+    @Test
+    void testGetImageT() {
+        final int size = 512;
+        final int sizeZ = 3;
+        final int sizeC = 5;
+        final int sizeT = 1;
+        ImagePlus imp  = ext.getImage(1L, "t:0");
+        assertEquals(size, imp.getWidth());
+        assertEquals(size, imp.getHeight());
+        assertEquals(sizeZ, imp.getNSlices());
+        assertEquals(sizeC, imp.getNChannels());
+        assertEquals(sizeT, imp.getNFrames());
+    }
+
 
     @Test
     void testSaveAndGetROIs() {

--- a/src/test/java/fr/igred/ij/plugin/OMEROExtensionTest.java
+++ b/src/test/java/fr/igred/ij/plugin/OMEROExtensionTest.java
@@ -322,32 +322,52 @@ class OMEROExtensionTest {
     }
 
 
-    @Test
-    void testGetImageTwoBounds() {
+    @ParameterizedTest
+    @ValueSource(strings = {"x:100:200 y:1:511", "x:50:150 y:2:512", "x:50:150 y:2:513"})
+    void testGetImageTwoBounds(String bounds) {
         final int partSize = 100;
-        final int fullSize = 512;
-        ImagePlus imp  = ext.getImage(1L, "x:100:200 y:0:512");
+        final int fullSize = 510;
+        ImagePlus imp  = ext.getImage(1L, bounds);
         assertEquals(partSize, imp.getWidth());
         assertEquals(fullSize, imp.getHeight());
     }
 
 
-    @Test
-    void testGetImageOneBound() {
+    @ParameterizedTest
+    @ValueSource(strings = {"x:100: y::412", "X:100: Y::412", "x::412 y:100:"})
+    void testGetImageOneBound(String bounds) {
         final int size = 412;
-        ImagePlus imp  = ext.getImage(1L, "x:100: y::412");
+        ImagePlus imp  = ext.getImage(1L, bounds);
         assertEquals(size, imp.getWidth());
         assertEquals(size, imp.getHeight());
     }
 
 
-    @Test
-    void testGetImageEmptyBounds() {
+    @ParameterizedTest
+    @ValueSource(strings = {"x:300:480 y:24:36 z:1:3 c:0:4 t:3:6", "X:300:480 Y:24:36 Z:1:3 C:0:4 T:3:6"})
+    void testGetImageAllBounds(String bounds) {
+        final int sizeX = 180;
+        final int sizeY = 12;
+        final int sizeZ = 2;
+        final int sizeC = 4;
+        final int sizeT = 3;
+        ImagePlus imp  = ext.getImage(1L, bounds);
+        assertEquals(sizeX, imp.getWidth());
+        assertEquals(sizeY, imp.getHeight());
+        assertEquals(sizeZ, imp.getNSlices());
+        assertEquals(sizeC, imp.getNChannels());
+        assertEquals(sizeT, imp.getNFrames());
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "  ", "x: y:: ", "x::9999 y:0:9999 z:50:99 c::99 t::99"})
+    void testGetImageNoBounds(String bounds) {
         final int size = 512;
         final int sizeZ = 3;
         final int sizeC = 5;
         final int sizeT = 7;
-        ImagePlus imp  = ext.getImage(1L, "x: ");
+        ImagePlus imp  = ext.getImage(1L, bounds);
         assertEquals(size, imp.getWidth());
         assertEquals(size, imp.getHeight());
         assertEquals(sizeZ, imp.getNSlices());
@@ -356,13 +376,14 @@ class OMEROExtensionTest {
     }
 
 
-    @Test
-    void testGetImageZ() {
+    @ParameterizedTest
+    @ValueSource(strings = {"z:0", "z:2", "Z:0", "z:0:1"})
+    void testGetImageZ(String bounds) {
         final int size = 512;
         final int sizeZ = 1;
         final int sizeC = 5;
         final int sizeT = 7;
-        ImagePlus imp  = ext.getImage(1L, "z:0");
+        ImagePlus imp  = ext.getImage(1L, bounds);
         assertEquals(size, imp.getWidth());
         assertEquals(size, imp.getHeight());
         assertEquals(sizeZ, imp.getNSlices());
@@ -371,13 +392,14 @@ class OMEROExtensionTest {
     }
 
 
-    @Test
-    void testGetImageC() {
+    @ParameterizedTest
+    @ValueSource(strings = {"c:0", "c:2", "C:0", "c:0:1"})
+    void testGetImageC(String bounds) {
         final int size = 512;
         final int sizeZ = 3;
         final int sizeC = 1;
         final int sizeT = 7;
-        ImagePlus imp  = ext.getImage(1L, "c:0");
+        ImagePlus imp  = ext.getImage(1L, bounds);
         assertEquals(size, imp.getWidth());
         assertEquals(size, imp.getHeight());
         assertEquals(sizeZ, imp.getNSlices());
@@ -386,13 +408,14 @@ class OMEROExtensionTest {
     }
 
 
-    @Test
-    void testGetImageT() {
+    @ParameterizedTest
+    @ValueSource(strings = {"t:0", "t:2", "T:0", "t:0:1"})
+    void testGetImageT(String bounds) {
         final int size = 512;
         final int sizeZ = 3;
         final int sizeC = 5;
         final int sizeT = 1;
-        ImagePlus imp  = ext.getImage(1L, "t:0");
+        ImagePlus imp  = ext.getImage(1L, bounds);
         assertEquals(size, imp.getWidth());
         assertEquals(size, imp.getHeight());
         assertEquals(sizeZ, imp.getNSlices());


### PR DESCRIPTION
Hello,
I wanted to be able to load subregions from my images (defined by ROIs in OMERO in my case), so here is my attempt for the implementation.

I made it so that the same function `getImage` is used, and subregion is an optional parameter.
I specify the coordinates in a string, that is parsed with a regex.

Range of the coordinates can be passed like so:
* `z:10:20` -> Z from 10 (incl) to 20 (excl)
* `z:10:` -> From slice 10 and on
* `z::10` -> Up to slice 10
* `z:10` -> Slice 10 only

The coordinate in the string are 0 indexed (so that I don't have a mix of XY in 0-index and CZT in 1-index). It became useful when reusing them as an "offset" for the upload of ROIs made from within those subregions.

I included two template macros:
* One to load subregions from ROIs on OMERO (with a tiny hack of opening a fake image first)
* One to upload ROIs of that subregions. IMPORTANT NOTE: it needs ImageJ 1.54g or higher (I had to update the ImageJ of a freshly downloaded Fiji). 

Also, I haven't complied javadoc (I get some errors, most likely from my setup), and I haven't run the tests (test image on my OMERO would have different IDs , etc). But I will add test functions soon.

Thank you for reviewing and let me know if there is anything to change / improve!

Tom
