### PR TITLE
KeyValue pairs functions implementation

### DIFF
--- a/src/main/java/fr/igred/ij/plugin/OMEROMacroExtension.java
+++ b/src/main/java/fr/igred/ij/plugin/OMEROMacroExtension.java
@@ -1192,14 +1192,13 @@ public class OMEROMacroExtension implements PlugIn, MacroExtension {
 
 
     /**
-     * Retrieves all the Key-Value pairs annotations of an object as a list
-     * of item in a String.
+     * Retrieves a concatenated string of all key-value pairs (keys should be unique).
      *
      * @param type      The object type.
      * @param id        The object ID.
-     * @param separator The thing used to separate the items in the string (default \t).
+     * @param separator The character(s) used to separate the items in the string (TAB by default).
      *
-     * @return The string with all the key-value pairs.
+     * @return The concatenated string of all key-value pairs for the specified repository object.
      */
     public String getKeyValuePairs(String type, long id, String separator) {
         Map<String, String> keyValuePairs = null;
@@ -1232,13 +1231,15 @@ public class OMEROMacroExtension implements PlugIn, MacroExtension {
 
 
     /**
-     * Retrieves the Value associated to the given Key of a Map annotation.
+     * Retrieves the Value associated to the given Key of a Map annotation. If no
+     * defaultValue is provided, generates an error.
      *
      * @param type         The object type.
      * @param id           The object ID.
+     * @param key          The key to return the value for.
      * @param defaultValue The default value to return if the key doesn't exist.
      *
-     * @return The value corresponding to the key for that object.
+     * @return The value associated to the key for the specified repository object.
      */
     public String getValue(String type, long id, String key, String defaultValue) {
         String result = null;

--- a/src/main/java/fr/igred/ij/plugin/OMEROMacroExtension.java
+++ b/src/main/java/fr/igred/ij/plugin/OMEROMacroExtension.java
@@ -20,6 +20,7 @@ import fr.igred.omero.Client;
 import fr.igred.omero.GenericObjectWrapper;
 import fr.igred.omero.annotations.TableWrapper;
 import fr.igred.omero.annotations.TagAnnotationWrapper;
+import fr.igred.omero.annotations.MapAnnotationWrapper;
 import fr.igred.omero.exception.AccessException;
 import fr.igred.omero.exception.OMEROServerError;
 import fr.igred.omero.exception.ServiceException;
@@ -58,6 +59,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -107,6 +109,8 @@ public class OMEROMacroExtension implements PlugIn, MacroExtension {
             newDescriptor("getROIs", this, ARG_NUMBER, ARG_NUMBER + ARG_OPTIONAL, ARG_STRING + ARG_OPTIONAL),
             newDescriptor("saveROIs", this, ARG_NUMBER, ARG_STRING + ARG_OPTIONAL),
             newDescriptor("removeROIs", this, ARG_NUMBER, ARG_STRING + ARG_OPTIONAL),
+            newDescriptor("getKeyValuePairs", this, ARG_STRING, ARG_NUMBER, ARG_STRING + ARG_OPTIONAL),
+            newDescriptor("getValue", this, ARG_STRING, ARG_NUMBER, ARG_STRING, ARG_STRING + ARG_OPTIONAL),
             newDescriptor("sudo", this, ARG_STRING),
             newDescriptor("endSudo", this),
             newDescriptor("disconnect", this),
@@ -1188,6 +1192,73 @@ public class OMEROMacroExtension implements PlugIn, MacroExtension {
 
 
     /**
+     * Retrieves all the Key-Value pairs annotations of an object as a list
+     * of item in a String.
+     *
+     * @param type      The object type.
+     * @param id        The object ID.
+     * @param separator The thing used to separate the items in the string (default \t).
+     *
+     * @return The string with all the key-value pairs.
+     */
+    public String getKeyValuePairs(String type, long id, String separator) {
+        Map<String, String> keyValuePairs = null;
+
+        if (separator == null)
+            separator = "\t";
+
+        GenericObjectWrapper<?> object = getObject(type, id);
+        try{
+            keyValuePairs = ((GenericRepositoryObjectWrapper<?>) object).getKeyValuePairs(client);
+        } catch (ServiceException | AccessException | ExecutionException e) {
+            IJ.error("Could not retrieve object: " + e.getMessage());
+        }
+
+        // Convert to a TreeMap for predictable alphabetical order
+        keyValuePairs = new TreeMap(keyValuePairs);
+
+        StringBuilder concatenatedString = new StringBuilder();
+        for (Map.Entry<String, String> entry : keyValuePairs.entrySet()) {
+            concatenatedString.append(entry.getKey())
+                              .append(separator)
+                              .append(entry.getValue())
+                              .append(separator);
+        }
+        if (concatenatedString.length() > 0) {
+            concatenatedString.setLength(concatenatedString.length() - separator.length());
+        }
+        return concatenatedString.toString();
+    }
+
+
+    /**
+     * Retrieves the Value associated to the given Key of a Map annotation.
+     *
+     * @param type         The object type.
+     * @param id           The object ID.
+     * @param defaultValue The default value to return if the key doesn't exist.
+     *
+     * @return The value corresponding to the key for that object.
+     */
+    public String getValue(String type, long id, String key, String defaultValue) {
+        String result = null;
+
+        GenericObjectWrapper<?> object = getObject(type, id);
+        try{
+            result = ((GenericRepositoryObjectWrapper<?>) object).getValue(client, key);
+        } catch (NoSuchElementException e) {
+            if (defaultValue != null)
+                result = defaultValue;
+            else
+                IJ.error("Could not retrieve value: " + e.getMessage());
+        } catch (ServiceException | AccessException | ExecutionException e) {
+            IJ.error("Could not retrieve value: " + e.getMessage());
+        }
+        return result;
+    }
+
+
+    /**
      * Removes the ROIs from an image in OMERO.
      *
      * @param id The image ID on OMERO.
@@ -1428,6 +1499,21 @@ public class OMEROMacroExtension implements PlugIn, MacroExtension {
                 id = ((Double) args[0]).longValue();
                 int removed = removeROIs(id);
                 results = String.valueOf(removed);
+                break;
+
+            case "getKeyValuePairs":
+                type = (String) args[0];
+                id = ((Double) args[1]).longValue();
+                String separator = (String) args[2];
+                results = getKeyValuePairs(type, id, separator);
+                break;
+
+            case "getValue":
+                type = (String) args[0];
+                id = ((Double) args[1]).longValue();
+                String key = (String) args[2];
+                String defaultValue = (String) args[3];
+                results = getValue(type, id, key, defaultValue);
                 break;
 
             case "sudo":

--- a/src/main/resources/script_templates/OMERO/Macro_Extensions/Read_key-value_pairs.ijm
+++ b/src/main/resources/script_templates/OMERO/Macro_Extensions/Read_key-value_pairs.ijm
@@ -1,0 +1,35 @@
+// @String(label="Username") USERNAME
+// @String(label="Password", style='password', persist=false) PASSWORD
+// @String(label="Host", value='wss://workshop.openmicroscopy.org/omero-ws') HOST
+// @Integer(label="Port", value=443) PORT
+// @Integer(label="Dataset ID", value=2331) dataset_id
+
+run("OMERO Extensions");
+
+connected = Ext.connectToOMERO(HOST, PORT, USERNAME, PASSWORD);
+
+if(connected == "true") {
+	// Read all key value pairs from a dataset
+	kvs_dataset = Ext.getKeyValuePairs("dataset", dataset_id);
+	
+	// Default separator is a TAB
+	kvs_dataset = split(kvs_dataset, "\t"); 
+	// ! If some cells are empty, split will ignore the double separators
+	// -> add a space between them first with replace(kvs_dataset, "\t\t", "\t \t");
+	
+	for(j=0; j<kvs_dataset.length; j=j+2){
+		// Every even index is the key, every odd index is the value
+		print(kvs_dataset[j] + ": " + kvs_dataset[j+1]);
+	}
+	
+    images = Ext.list("images", "dataset", dataset_id);
+    image_ids = split(images, ",");
+    for(i=0; i<image_ids.length; i++) {
+	    // Read from each image the value associated to the "condition" key 
+		condition_image = Ext.getValue("image", image_ids[i], "condition");
+		print(condition_image);
+    }
+}
+
+Ext.disconnect();
+print("processing done");

--- a/src/test/java/fr/igred/ij/plugin/OMEROExtensionErrorTest.java
+++ b/src/test/java/fr/igred/ij/plugin/OMEROExtensionErrorTest.java
@@ -218,4 +218,14 @@ class OMEROExtensionErrorTest {
         assertEquals(expected, outContent.toString().trim());
     }
 
+    @Test
+    void testKeyNotExist() {
+        final String key = "notExist";
+        final double imageId = 2;
+        Object[]     args      = {"image", imageId, key, null};
+        ext.handleExtension("getValue", args);
+        String expected = "Could not retrieve value: Key \"" + key + "\" not found";
+        assertEquals(expected, outContent.toString().trim());
+    }
+
 }

--- a/src/test/java/fr/igred/ij/plugin/OMEROExtensionTest.java
+++ b/src/test/java/fr/igred/ij/plugin/OMEROExtensionTest.java
@@ -344,6 +344,27 @@ class OMEROExtensionTest {
     }
 
 
+    @ParameterizedTest
+    @CsvSource(delimiter = ';', value = {"image;1;null;testKey1\ttestValue1\ttestKey2\t20",
+                                         "image;3;' ';testKey1 testValue1 testKey2 20",
+                                         "image;2;&&;testKey1&&testValue2&&testKey2&&30",
+                                         "image;4;'';''"}, nullValues={"null"})
+    void testgetKeyValuePairs(String type, Long id, String separator, String output) {
+        String result = ext.getKeyValuePairs(type, id, separator);
+        assertEquals(output, result);
+    }
+
+    @ParameterizedTest
+    @CsvSource(delimiter = ';', value = {"image;1;testKey1;null;testValue1",
+                                         "image;3;testKey2;null;20",
+                                         "image;2;testKey2;null;30",
+                                         "image;2;notExist;default;default"}, nullValues={"null"})
+    void testgetValue(String type, Long id, String key, String defaultValue, String output) {
+        String result = ext.getValue(type, id, key, defaultValue);
+        assertEquals(output, result);
+    }
+
+
     @Test
     void testImportImage() throws IOException {
         String path = "8bit-unsigned&pixelType=uint8&sizeZ=3&sizeC=5&sizeT=7&sizeX=512&sizeY=512.fake";


### PR DESCRIPTION
Hello Pierre,
I needed Key-Value pairs as inputs for another project with Fiji macros. 

I start to find my way in your very nice simple-omero-client library, so I thought I could also contribute this small piece to the macro extension.

I have two functions:
* `getValue`: Retrieves the Value associated with a Key for a given object type and ID. Users can also provide a default value in case the Key doesn't exist, depending whether they want the script to fail or not in the absence of the key.
* `getKeyValuePairs`: Retrieves a concatenated string of all key-value pairs (keys should be unique). The default separator is a tab, but can be specified.

Tom